### PR TITLE
Update CTCall.h

### DIFF
--- a/CoreTelephony/CTCall.h
+++ b/CoreTelephony/CTCall.h
@@ -81,8 +81,8 @@ extern "C" {
 
     CFStringRef CTCallCopyUniqueStringID(CFAllocatorRef allocator, CTCallRef call);
 
-    double CTCallGetDuration(CTCallRef call);
-    double CTCallGetStartTime(CTCallRef call);
+    BOOL CTCallGetStartTime(CTCallRef, double *);
+    BOOL CTCallGetDuration(CTCallRef, double *);
 
     CTCallStatus CTCallGetStatus(CTCallRef call);
     CTCallType CTCallGetCallType(CTCallRef call);


### PR DESCRIPTION
The prototypes of CTCallGetStartTime and CTCallGetDuration are wrong, but seems the 2 buffers are always filled with 0.0
